### PR TITLE
"device" parameter

### DIFF
--- a/config_webrx.py
+++ b/config_webrx.py
@@ -105,7 +105,7 @@ sdrs = {
         "name": "RTL-SDR USB Stick",
         "type": "rtl_sdr",
         "ppm": 0,
-        "device": "0",
+        "device": "",
         # you can change this if you use an upconverter. formula is:
         # shown_center_freq = center_freq + lfo_offset
         # "lfo_offset": 0,
@@ -132,7 +132,7 @@ sdrs = {
         "name": "SDRPlay RSP2",
         "type": "sdrplay",
         "ppm": 0,
-        "device": "0",
+        "device": "",
         "profiles": {
             "20m": {
                 "name": "20m",

--- a/config_webrx.py
+++ b/config_webrx.py
@@ -98,12 +98,14 @@ Note: if you experience audio underruns while CPU usage is 100%, you can:
 #################################################################################################
 
 # Currently supported types of sdr receivers: "rtl_sdr", "sdrplay", "hackrf", "airspy"
+# With "hackrf, airspy" , "device" is the device of specified serial number
 
 sdrs = {
     "rtlsdr": {
         "name": "RTL-SDR USB Stick",
         "type": "rtl_sdr",
         "ppm": 0,
+        "device": "0",
         # you can change this if you use an upconverter. formula is:
         # shown_center_freq = center_freq + lfo_offset
         # "lfo_offset": 0,
@@ -130,6 +132,7 @@ sdrs = {
         "name": "SDRPlay RSP2",
         "type": "sdrplay",
         "ppm": 0,
+        "device": "0",
         "profiles": {
             "20m": {
                 "name": "20m",
@@ -260,7 +263,7 @@ wsjt_decoding_depth = 3
 # jt65 seems to be somewhat prone to erroneous decodes, this setting handles that to some extent
 wsjt_decoding_depths = {"jt65": 1}
 
-temporary_directory = "/tmp"
+temporary_directory = "/dev/shm"
 
 services_enabled = False
 services_decoders = ["ft8", "ft4", "wspr", "packet"]

--- a/owrx/source.py
+++ b/owrx/source.py
@@ -379,7 +379,7 @@ class Resampler(SdrSource):
 class RtlSdrSource(SdrSource):
     def getCommand(self):
         command = "rtl_sdr -s {samp_rate} -f {center_freq} -p {ppm} -g {rf_gain}"
-        if self.rtlProps["device"] != "0" :
+        if self.rtlProps["device"] != "" :
             command += " -d {device}"
         command += " -"
         return command
@@ -391,7 +391,7 @@ class RtlSdrSource(SdrSource):
 class HackrfSource(SdrSource):
     def getCommand(self):
         command="hackrf_transfer -s {samp_rate} -f {center_freq} -g {rf_gain} -l{lna_gain} -a{rf_amp} "
-        if self.rtlProps["device"] != "0" :
+        if self.rtlProps["device"] != "" :
             command += " -d {device}"
         command += " -r-"
         return command
@@ -413,7 +413,7 @@ class SdrplaySource(SdrSource):
             command += " -g {gains}".format(gains=",".join(gains))
         if self.rtlProps["antenna"] is not None:
             command += ' -a "{antenna}"'
-        if self.rtlProps["device"] != "0" :
+        if self.rtlProps["device"] != "" :
             command += " -d {device}"
         command += " -"
         return command
@@ -428,7 +428,7 @@ class AirspySource(SdrSource):
         command = "airspy_rx"
         command += " -f{0}".format(frequency)
         command += " -r /dev/stdout -a{samp_rate} -g {rf_gain}"
-        if self.rtlProps["device"] != "0" :
+        if self.rtlProps["device"] != "" :
             command += " -s {device}"
         return command
 


### PR DESCRIPTION
1, change temporary_directory to '/dev/shm' , I feel it is faster than '/tmp'
2, add a "device" parameter to the source config and source command, if "device": "" , it means not use "device" in the sdrcommand.