### PR TITLE
Add fallback to use OpenStreetMap/Wikipedia Maps

### DIFF
--- a/htdocs/map.js
+++ b/htdocs/map.js
@@ -215,13 +215,39 @@
                     case "config":
                         var config = json.value;
                         if (!map) $.getScript("https://maps.googleapis.com/maps/api/js?key=" + config.google_maps_api_key).done(function(){
-                            map = new google.maps.Map($('.openwebrx-map')[0], {
-                                center: {
-                                    lat: config.receiver_gps[0],
-                                    lng: config.receiver_gps[1]
-                                },
-                                zoom: 5
-                            });
+                            if (config.google_maps_api_key){
+                                map = new google.maps.Map($('.openwebrx-map')[0], {
+                                    center: {
+                                        lat: config.receiver_gps[0],
+                                        lng: config.receiver_gps[1]
+                                    },
+                                    zoom: 5
+                                });
+                            } else {
+                                var mapTypeIds = [];
+                                for(var type in google.maps.MapTypeId) {
+                                    mapTypeIds.push(google.maps.MapTypeId[type]);
+                                }
+                                mapTypeIds.push("OSM");
+
+                                map = new google.maps.Map($('.openwebrx-map')[0], {
+                                    center: {
+                                        lat: config.receiver_gps[0],
+                                        lng: config.receiver_gps[1]
+                                    },
+                                    zoom: 5,
+                                    mapTypeId: "OSM"
+                                });
+
+                                map.mapTypes.set("OSM", new google.maps.ImageMapType({
+                                    getTileUrl: function(coord, zoom) {
+                                        return "https://maps.wikimedia.org/osm-intl/" + zoom + "/" + coord.x + "/" + coord.y + ".png";
+                                    },
+                                    tileSize: new google.maps.Size(256, 256),
+                                    name: "OpenStreetMap",
+                                    maxZoom: 18
+                                }));
+                            }
                             $.getScript("static/lib/nite-overlay.js").done(function(){
                                 nite.init(map);
                                 setInterval(function() { nite.refresh() }, 10000); // every 10s


### PR DESCRIPTION
Greetings,

So if you don't have a Google Maps API Key and try to use the map in OpenWebRX, presently you get the dimmed out version of Google Maps which makes it somewhat hard to use.  It is possible to use [OpenStreetMap with the Google Map API](https://wiki.openstreetmap.org/wiki/Google_Maps_Example) to use OSM (in this case, Wikipedia's basemap). 

This bit of code uses an if / else to say that if a Google Maps API key isn't set, fall back to using the Wikipedia map as the basemap.  It needs to be tested with someone who has a Google Maps API (in which case, the Google Map should just be used as always) but I don't think that'll be an issue.  

This probably isn't as robust as say, switching from Google Maps API to Leaflet or a vector map but this relatively painless.  And since I went ahead and did it, I thought I'd offer it up here.  