### PR TITLE
Microtelecom Perseus HF receiver integration.

### DIFF
--- a/config_webrx.py
+++ b/config_webrx.py
@@ -99,13 +99,17 @@ Note: if you experience audio underruns while CPU usage is 100%, you can:
 #################################################################################################
 
 # Currently supported types of sdr receivers:
-# "rtl_sdr", "sdrplay", "hackrf", "airspy", "airspyhf", "fifi_sdr"
+# "rtl_sdr", "sdrplay", "hackrf", "airspy", "airspyhf", "fifi_sdr", "perseussdr"
 #
 # In order to use rtl_sdr, you will need to install librtlsdr-dev and the connector.
 # In order to use sdrplay, airspy or airspyhf, you will need to install soapysdr, the corresponding driver, and the
 # connector.
 #
 # https://github.com/jketterl/owrx_connector
+#
+# In order to use Perseus HF you need to install the libperseus-sdr
+#
+# https://github.com/Microtelecom/libperseus-sdr
 #
 # NOTE: The connector sources have replaced the old piped nmux style of reading input. If you still have any sdrs
 # configured that have type endin in "_connector", simply remove that suffix.
@@ -134,6 +138,53 @@ sdrs = {
                 "samp_rate": 2400000,
                 "start_freq": 145725000,
                 "start_mod": "nfm",
+            },
+        },
+    },
+    "perseussdr": {
+        "name": "Microtelecom Perseus HF receiver",
+        "type": "perseussdr",
+        "ppm": 0,
+        "profiles": {
+            "40m": {
+                "name": "40m",
+                "center_freq": 7150000,
+                "rf_gain": 0,
+                "samp_rate": 500000,
+                "start_freq": 7050000,
+                "start_mod": "lsb",
+            },
+            "20m": {
+                "name": "20m",
+                "center_freq": 14150000,
+                "rf_gain": 0,
+                "samp_rate": 500000,
+                "start_freq": 14070000,
+                "start_mod": "usb",
+            },
+            "30m": {
+                "name": "30m",
+                "center_freq": 10125000,
+                "rf_gain": 0,
+                "samp_rate": 192000,
+                "start_freq": 10142000,
+                "start_mod": "usb",
+            },
+            "80m": {
+                "name": "80m",
+                "center_freq": 3650000,
+                "rf_gain": 0,
+                "samp_rate": 500000,
+                "start_freq": 3570000,
+                "start_mod": "usb",
+            },
+            "49m": {
+                "name": "49m Broadcast",
+                "center_freq": 6000000,
+                "rf_gain": 0,
+                "samp_rate": 500000,
+                "start_freq": 6070000,
+                "start_mod": "am",
             },
         },
     },

--- a/owrx/feature.py
+++ b/owrx/feature.py
@@ -25,6 +25,7 @@ class FeatureDetector(object):
         "rtl_sdr_soapy": ["soapy_connector", "soapy_rtl_sdr"],
         "sdrplay": ["soapy_connector", "soapy_sdrplay"],
         "hackrf": ["hackrf_transfer"],
+        "perseussdr": ["perseustest"],
         "airspy": ["soapy_connector", "soapy_airspy"],
         "airspyhf": ["soapy_connector", "soapy_airspyhf"],
         "lime_sdr": ["soapy_connector", "soapy_lime_sdr"],
@@ -149,6 +150,26 @@ class FeatureDetector(object):
         # TODO i don't have a hackrf, so somebody doublecheck this.
         # TODO also check if it has the stdout feature
         return self.command_is_runnable("hackrf_transfer --help")
+
+    def has_perseustest(self):
+        """
+        To use a Microtelecom Perseus HF receiver, compile and
+        install the libperseus-sdr:
+        ```
+         sudo apt install libusb-1.0-0-dev
+         cd /tmp
+         wget https://github.com/Microtelecom/libperseus-sdr/releases/download/v0.7.5/libperseus_sdr-0.7.5.tar.gz
+         tar -zxvf libperseus_sdr-0.7.5.tar.gz
+         cd libperseus_sdr-0.7.5/
+         ./configure
+         make
+         sudo make install
+         sudo ldconfig
+         perseustest
+        ```
+        """
+        return self.command_is_runnable("perseustest -d -1 -a -t 1")
+
 
     def has_digiham(self):
         """

--- a/owrx/source/perseussdr.py
+++ b/owrx/source/perseussdr.py
@@ -1,0 +1,31 @@
+from .direct import DirectSource
+from owrx.command import Flag, Option
+
+
+#
+# perseustest -s 768000 -u 0 -f 14150000 -r-|csdr convert_s8_f|nmux --bufsize 192512 --bufcnt 260 --port 35989 --address 127.0.0.1
+# perseustest -a -t0    -o -
+# perseustest -d 9 -a -t 100000 -o -  -s 768000 -u 0 -f 14150000 -r-
+
+class PerseussdrSource(DirectSource):
+    def getCommandMapper(self):
+        return super().getCommandMapper().setBase("perseustest -p -d -1 -a -t 100000 -o -  ").setMappings(
+            {
+                "samp_rate": Option("-s"),
+                "tuner_freq": Option("-f"),
+                "rf_gain": Option("-u"),
+                "lna_gain": Option("-g"),
+                "rf_amp": Option("-x"),
+            }
+        ).setStatic("-r-")
+
+    def getEventNames(self):
+        return super().getEventNames() + [
+            "lna_gain",
+            "rf_amp",
+        ]
+
+    def getFormatConversion(self):
+#        return ["csdr convert_s24_f --bigendian"]
+#        return ["csdr convert_s24_f", "csdr gain_ff 20"]
+        return ["csdr gain_ff 20"]


### PR DESCRIPTION
Microtelecom Perseus HF receiver integration.
It requires libperseus-sdr as a prerequisite:
https://github.com/Microtelecom/libperseus-sdr