### PR TITLE
hackrf: properly use ppm setting as parameter

### DIFF
--- a/owrx/source/hackrf.py
+++ b/owrx/source/hackrf.py
@@ -11,6 +11,7 @@ class HackrfSource(DirectSource):
                 "rf_gain": Option("-g"),
                 "lna_gain": Option("-l"),
                 "rf_amp": Option("-a"),
+                "ppm": Option("-C"),
             }
         ).setStatic("-r-")
 


### PR DESCRIPTION
The hackrf source is currently not passing the ppm option to `hackrf_transfer`. This patch makes owrx pass the ppm option as argument `-C` to the `hackrf_transfer` program.