### PR TITLE
Round frequency to 100Hz when clicking FFT display

### DIFF
--- a/htdocs/openwebrx.js
+++ b/htdocs/openwebrx.js
@@ -545,7 +545,7 @@ function canvas_mouseup(evt) {
     var relativeX = get_relative_x(evt);
 
     if (!canvas_drag) {
-        $('#openwebrx-panel-receiver').demodulatorPanel().getDemodulator().set_offset_frequency(canvas_get_freq_offset(relativeX));
+        $('#openwebrx-panel-receiver').demodulatorPanel().getDemodulator().set_offset_frequency(Math.round(canvas_get_freq_offset(relativeX)/100)*100);
     }
     else {
         canvas_end_drag();


### PR DESCRIPTION
Currently OWRX displays the tuner frequency in MHz with 4 decimal digits, omitting the last two.  When clicking on the FFT waterfall it is then impossible to see which frequency you actually tuned to, and exactly 99 out of 100 times, it's not the one you want.  Especially for SSB transmissions it's very impractical to tune by clicking, you end up always entering the frequency manually.

Solution: round the frequency to a multiple of 100Hz.  I find that this one simple tweak is a massive increase in usability.  Ideally I think the tuner window should show the full frequency in Hz, with a selection dropdown for grid/step size.  I'd have to study the code more (and learn js) if I were to implement that, however.  For now, I think this small change is already a step in the right direction.