### PR TITLE
Highlight frequency digits on mouse hover

### DIFF
--- a/htdocs/css/openwebrx.css
+++ b/htdocs/css/openwebrx.css
@@ -344,6 +344,13 @@ input[type=range]:disabled {
 	line-height: 22px;
 }
 
+.webrx-actual-freq .digit:hover {
+	color: #FFFF50;
+	border-radius: 5px;
+	background: -webkit-gradient( linear, left top, left bottom, color-stop(0.0 , #373737), color-stop(1, #4F4F4F) );
+	background: -moz-linear-gradient( center top, #373737 0%, #4F4F4F 100% );
+}
+
 .webrx-mouse-freq {
 	width: 100%;
 	text-align: left;


### PR DESCRIPTION
The ability to change frequency by scrolling over the frequency display is rather obscure.  The counter appears as regular text, with no visual indication that any interaction is possible.

This patch will highlight each digit when moving the mouse over it, notifying the user that there is some action associated with the individual digits.  This should make it more obvious that this feature exists.

Alternatively, the background on each digit could remain visible so that it looks more like a mechanical counter, with only the text turning yellow on hover, e.g.:
```
.webrx-actual-freq .digit {
    margin-right: 2px;
    padding: 0 2px 0 2px;
    border-radius: 5px;
    background: -webkit-gradient( linear, left top, left bottom, color-stop(0.0 , #373737), color-stop(1, #4F4F4F) );
    background: -moz-linear-gradient( center top, #373737 0%, #4F4F4F 100% );
}

.webrx-actual-freq .digit:hover {
    color: #FFFF50;
}
```