### PR TITLE
Support for HPSDR radios (specifically, the Hermes-Lite 2)

### DIFF
--- a/config_webrx.py
+++ b/config_webrx.py
@@ -99,7 +99,7 @@ digital_voice_unvoiced_quality = 1
 digital_voice_dmr_id_lookup = True
 
 """
-Note: if you experience audio underruns while CPU usage is 100%, you can: 
+Note: if you experience audio underruns while CPU usage is 100%, you can:
 - decrease `samp_rate`,
 - set `fft_voverlap_factor` to 0,
 - decrease `fft_fps` and `fft_size`,
@@ -116,7 +116,7 @@ Note: if you experience audio underruns while CPU usage is 100%, you can:
 
 # Currently supported types of sdr receivers:
 # "rtl_sdr", "rtl_sdr_soapy", "sdrplay", "hackrf", "airspy", "airspyhf", "fifi_sdr",
-# "perseussdr", "lime_sdr", "pluto_sdr", "soapy_remote"
+# "perseussdr", "lime_sdr", "pluto_sdr", "soapy_remote", "hpsdr"
 #
 # In order to use rtl_sdr, you will need to install librtlsdr-dev and the connector.
 # In order to use sdrplay, airspy or airspyhf, you will need to install soapysdr, the corresponding driver, and the

--- a/owrx/feature.py
+++ b/owrx/feature.py
@@ -68,6 +68,7 @@ class FeatureDetector(object):
         "red_pitaya": ["soapy_connector", "soapy_red_pitaya"],
         "radioberry": ["soapy_connector", "soapy_radioberry"],
         "fcdpp": ["soapy_connector", "soapy_fcdpp"],
+        "hpsdr": ["hpsdr_connector"],
         # optional features and their requirements
         "digital_voice_digiham": ["digiham", "sox"],
         "digital_voice_dsd": ["dsd", "sox", "digiham"],
@@ -492,3 +493,10 @@ class FeatureDetector(object):
         [OpenWebRX wiki](https://github.com/jketterl/openwebrx/wiki/DRM-demodulator-notes).
         """
         return self.command_is_runnable("dream --help", 0)
+
+    def has_hpsdr_connector(self):
+        """
+        In order to use the HPSDR connector, you will need to install [hpsdrconnector]
+        (https://github.com/jancona/hpsdrconnector).
+        """
+        return self.command_is_runnable("hpsdrconnector -h")

--- a/owrx/source/hpsdr.py
+++ b/owrx/source/hpsdr.py
@@ -1,4 +1,4 @@
-from .direct import DirectSource
+from .connector import ConnectorSource
 from owrx.command import Flag, Option
 
 # In order to use an HPSDR radio, you must install hpsdrconnector from https://github.com/jancona/hpsdrconnector
@@ -11,21 +11,24 @@ from owrx.command import Flag, Option
 #     	IP address of radio (default use first radio discovered)
 #   --samplerate uint
 #     	Use the specified samplerate: one of 48000, 96000, 192000, 384000 (default 96000)
+#   --debug
+#       Emit debug log messages on stdout
 #
 # If you omit `remote` from config_webrx.py, hpsdrconnector will use the HPSDR discovery protocol
 # to find radios on your local network and will connect to the first radio it discovered.
 
-class HpsdrSource(DirectSource):
+class HpsdrSource(ConnectorSource):
     def getCommandMapper(self):
-        return super().getCommandMapper().setBase("hpsdrconnector").setMappings(
+        return (
+            super()
+            .getCommandMapper()
+            .setBase("hpsdrconnector")
+            .setMappings(
             {
                 "tuner_freq": Option("--frequency"),
                 "samp_rate": Option("--samplerate"),
                 "remote": Option("--radio"),
                 "rf_gain": Option("--gain"),
-            }
+                "debug": Flag("--debug"),
+            })
         )
-
-    def getFormatConversion(self):
-        return ["csdr convert_s24_f"]
-

--- a/owrx/source/hpsdr.py
+++ b/owrx/source/hpsdr.py
@@ -29,6 +29,5 @@ class HpsdrSource(ConnectorSource):
                 "samp_rate": Option("--samplerate"),
                 "remote": Option("--radio"),
                 "rf_gain": Option("--gain"),
-                "debug": Flag("--debug"),
             })
         )

--- a/owrx/source/hpsdr.py
+++ b/owrx/source/hpsdr.py
@@ -1,0 +1,31 @@
+from .direct import DirectSource
+from owrx.command import Flag, Option
+
+# In order to use an HPSDR radio, you must install hpsdrconnector from https://github.com/jancona/hpsdrconnector
+# These are the command line options available:
+#  --frequency uint
+#    	Tune to specified frequency in Hz (default 7100000)
+#  --gain uint
+#    	LNA gain between 0 (-12dB) and 60 (48dB) (default 20)
+#   --radio string
+#     	IP address of radio (default use first radio discovered)
+#   --samplerate uint
+#     	Use the specified samplerate: one of 48000, 96000, 192000, 384000 (default 96000)
+#
+# If you omit `remote` from config_webrx.py, hpsdrconnector will use the HPSDR discovery protocol
+# to find radios on your local network and will connect to the first radio it discovered.
+
+class HpsdrSource(DirectSource):
+    def getCommandMapper(self):
+        return super().getCommandMapper().setBase("hpsdrconnector").setMappings(
+            {
+                "tuner_freq": Option("--frequency"),
+                "samp_rate": Option("--samplerate"),
+                "remote": Option("--radio"),
+                "rf_gain": Option("--gain"),
+            }
+        )
+
+    def getFormatConversion(self):
+        return ["csdr convert_s24_f"]
+


### PR DESCRIPTION
This uses a connector I wrote: https://github.com/jancona/hpsdrconnector

See the README in that repo for installation instructions and current limitations.