### PR TITLE
correct typo, and prevent warning during postinstall

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euxo pipefail
 
-adduser --system --group --no-create-home --home /nonexistant openwebrx
+adduser --system --group --no-create-home --home /nonexistent --quiet openwebrx
 usermod -aG plugdev openwebrx
 
 #DEBHELPER#


### PR DESCRIPTION
Hi Jakob,

I noticed a warning during today's update.

Please have a look, I believe this is how it is intended.


```
root@websdr:/home/pd1acf/openwebrx# adduser --system --group --no-create-home --home /nonexistent --quiet openwebrx
root@websdr:/home/pd1acf/openwebrx# echo $?
0

```