### PR TITLE
Expose Prometheus-compatible metrics at /metrics

### DIFF
--- a/owrx/controllers/metrics.py
+++ b/owrx/controllers/metrics.py
@@ -1,9 +1,24 @@
 from . import Controller
-from owrx.metrics import Metrics
-import json
+from owrx.metrics import CounterMetric, DirectMetric, Metrics
 
 
 class MetricsController(Controller):
     def indexAction(self):
-        data = json.dumps(Metrics.getSharedInstance().getMetrics())
-        self.send_response(data, content_type="application/json")
+        metrics = Metrics.getSharedInstance().metrics
+
+        data = "# https://prometheus.io/docs/instrumenting/exposition_formats/\n"
+        for key,metric in metrics.items():
+
+            value = -1
+
+            if isinstance(metric, CounterMetric):
+                key += "_total"
+                value = metric.getValue()["count"]
+            elif isinstance(metric, DirectMetric):
+                value = metric.getValue()
+            else:
+                raise ValueError("Unexpected metric type for metric %s" % repr(metric))
+
+            data += "%s %s\n" % (key.replace(".", "_"), value)
+
+        self.send_response(data, content_type="text/plain; version=0.0.4")


### PR DESCRIPTION
This is a rough first-draft change, with multiple flaws, intended to
just start discussion around the feature request.

Issues include:

* It breaks compatibility, replacing the previous JSON /metrics
* It crudely hand-generates Prometheus-formatted data
* It would probably be better if it used
https://pypi.org/project/prometheus-client/

But it works locally and I have some nice graphs!