### PR TITLE
User Customization of APRS IGate Beacon Details

### DIFF
--- a/config_webrx.py
+++ b/config_webrx.py
@@ -336,6 +336,35 @@ aprs_igate_beacon = False
 # path to the aprs symbols repository (get it here: https://github.com/hessu/aprs-symbols)
 aprs_symbols_path = "/usr/share/aprs-symbols/png"
 
+# Uncomment the following to customize gateway beacon details reported to the aprs network
+#   Plese see Dire Wolf's documentation on PBEACON configuration for complete details:
+#   https://github.com/wb2osz/direwolf/raw/master/doc/User-Guide.pdf 
+
+# Symbol in its two-character form as specified by the APRS spec at http://www.aprs.org/symbols/symbols-new.txt
+#   Default: Receive only IGate (do not send msgs back to RF)  
+# aprs_igate_symbol = "R&"
+# Custom comment about igate 
+#   Default: OpenWebRX APRS gateway
+# aprs_igate_comment = "OpenWebRX APRS gateway"
+
+# Antenna Power, Height, Gain, and Direction 
+#  Unspecified by default
+# Transmitter power (0 by default as only RX is supported)
+# aprs_igate_power = "0"
+# Antenna height in feet
+# aprs_igate_height = "20"
+# Antenna gain in dBi
+# aprs_igate_gain = "0"
+# Antenna direction (N, NE, E, SE, S, SW, W, NW).  Omnidirectional by default
+# aprs_igate_dir = "NE"
+
+# Frequency info to contact you by voice
+#   Unspecified by default
+# aprs_igate_freq = "146.955"
+# aprs_igate_tone = "74.4"
+# aprs_igate_offset = "-0.60"
+
+
 # === PSK Reporter setting ===
 # enable this if you want to upload all ft8, ft4 etc spots to pskreporter.info
 # this also uses the receiver_gps setting from above, so make sure it contains a correct locator

--- a/config_webrx.py
+++ b/config_webrx.py
@@ -343,12 +343,13 @@ aprs_symbols_path = "/usr/share/aprs-symbols/png"
 # Symbol in its two-character form as specified by the APRS spec at http://www.aprs.org/symbols/symbols-new.txt
 #   Default: Receive only IGate (do not send msgs back to RF)  
 # aprs_igate_symbol = "R&"
+
 # Custom comment about igate 
 #   Default: OpenWebRX APRS gateway
 # aprs_igate_comment = "OpenWebRX APRS gateway"
 
 # Antenna Power, Height, Gain, and Direction 
-#  Unspecified by default
+#   Unspecified by default
 # Transmitter power (0 by default as only RX is supported)
 # aprs_igate_power = "0"
 # Antenna height in feet

--- a/config_webrx.py
+++ b/config_webrx.py
@@ -348,7 +348,7 @@ aprs_symbols_path = "/usr/share/aprs-symbols/png"
 #   Default: OpenWebRX APRS gateway
 # aprs_igate_comment = "OpenWebRX APRS gateway"
 
-# Antenna Power, Height, Gain, and Direction 
+# Antenna Power, Height, Gain 
 #   Unspecified by default
 # Transmitter power (0 by default as only RX is supported)
 # aprs_igate_power = "0"

--- a/config_webrx.py
+++ b/config_webrx.py
@@ -348,23 +348,14 @@ aprs_symbols_path = "/usr/share/aprs-symbols/png"
 #   Default: OpenWebRX APRS gateway
 # aprs_igate_comment = "OpenWebRX APRS gateway"
 
-# Antenna Power, Height, Gain 
+# Antenna Height and Gain details
 #   Unspecified by default
-# Transmitter power (0 by default as only RX is supported)
-# aprs_igate_power = "0"
-# Antenna height in feet
-# aprs_igate_height = "20"
+# Antenna height above average terrain (HAAT) in meters 
+# aprs_igate_height = "5"
 # Antenna gain in dBi
 # aprs_igate_gain = "0"
 # Antenna direction (N, NE, E, SE, S, SW, W, NW).  Omnidirectional by default
 # aprs_igate_dir = "NE"
-
-# Frequency info to contact you by voice
-#   Unspecified by default
-# aprs_igate_freq = "146.955"
-# aprs_igate_tone = "74.4"
-# aprs_igate_offset = "-0.60"
-
 
 # === PSK Reporter setting ===
 # enable this if you want to upload all ft8, ft4 etc spots to pskreporter.info

--- a/owrx/kiss.py
+++ b/owrx/kiss.py
@@ -64,10 +64,10 @@ IGLOGIN {callsign} {password}
                 if "aprs_igate_height":
                     try:
                         height_m = float(pm["aprs_igate_height"])
-                        height_ft = int(height_m * FEET_PER_METER)
+                        height_ft = round(height_m * FEET_PER_METER)
                         height = "HEIGHT=" + str(height_ft)
                     except:
-                        logger.error("Cannot parse 'aprs_igate_height': " + str(pm["aprs_igate_height"]))
+                        logger.error("Cannot parse 'aprs_igate_height', expected float: " + str(pm["aprs_igate_height"]))
 
                 if((len(comment) > 0) and ((comment[0] != '"') or (comment[len(comment)-1] != '"'))):
                     comment = "\"" + comment + "\""

--- a/owrx/kiss.py
+++ b/owrx/kiss.py
@@ -50,15 +50,15 @@ IGLOGIN {callsign} {password}
                 lon = "{0:03d}^{1:05.2f}{2}".format(int(lon), (lon - int(lon)) * 60, direction_we)
 
                 #Format beacon details
-                symbol  = str(pm["aprs_igate_symbol"])             if checkKey(pm, "aprs_igate_symbol")  else "R&"
-                power   = str(pm["aprs_igate_power"])              if checkKey(pm, "aprs_igate_power")   else "0"
-                height  = "HEIGHT=" + str(pm["aprs_igate_height"]) if checkKey(pm, "aprs_igate_height")  else ""
-                gain    = "GAIN=" + str(pm["aprs_igate_gain"])     if checkKey(pm, "aprs_igate_gain")    else ""
-                adir    = "DIR=" + str(pm["aprs_igate_dir"])       if checkKey(pm, "aprs_igate_dir")     else ""
-                freq    = "FREQ=" + str(pm["aprs_igate_freq"])     if checkKey(pm, "aprs_igate_freq")    else ""
-                tone    = "TONE=" + str(pm["aprs_igate_tone"])     if checkKey(pm, "aprs_igate_tone")    else ""
-                offset  = "OFFSET=" + str(pm["aprs_igate_offset"]) if checkKey(pm, "aprs_igate_offset")  else ""
-                comment = str(pm["aprs_igate_comment"])            if checkKey(pm, "aprs_igate_comment") else "OpenWebRX APRS gateway"
+                symbol  = str(pm["aprs_igate_symbol"])             if "aprs_igate_symbol"  in pm else "R&"
+                power   = str(pm["aprs_igate_power"])              if "aprs_igate_power"   in pm else "0"
+                height  = "HEIGHT=" + str(pm["aprs_igate_height"]) if "aprs_igate_height"  in pm else ""
+                gain    = "GAIN=" + str(pm["aprs_igate_gain"])     if "aprs_igate_gain"    in pm else ""
+                adir    = "DIR=" + str(pm["aprs_igate_dir"])       if "aprs_igate_dir"     in pm else ""
+                freq    = "FREQ=" + str(pm["aprs_igate_freq"])     if "aprs_igate_freq"    in pm else ""
+                tone    = "TONE=" + str(pm["aprs_igate_tone"])     if "aprs_igate_tone"    in pm else ""
+                offset  = "OFFSET=" + str(pm["aprs_igate_offset"]) if "aprs_igate_offset"  in pm else ""
+                comment = str(pm["aprs_igate_comment"])            if "aprs_igate_comment" in pm else "OpenWebRX APRS gateway"
 
                 config += """
 PBEACON sendto=IG delay=0:30 every=60:00 symbol={symbol} lat={lat} long={lon} POWER={power} {height} {gain} {adir} {freq} {tone} {offset} comment={comment}

--- a/owrx/kiss.py
+++ b/owrx/kiss.py
@@ -60,6 +60,9 @@ IGLOGIN {callsign} {password}
                 offset  = "OFFSET=" + str(pm["aprs_igate_offset"]) if "aprs_igate_offset"  in pm else ""
                 comment = str(pm["aprs_igate_comment"])            if "aprs_igate_comment" in pm else "\"OpenWebRX APRS gateway\""
 
+                if(comment[0] != '"'):
+                    comment = "\"" + comment + "\""
+
                 pbeacon= "PBEACON sendto=IG delay=0:30 every=60:00 symbol={symbol} lat={lat} long={lon} POWER={power} {height} {gain} {adir} {freq} {tone} {offset} comment={comment}".format(
                     symbol=symbol, lat=lat, lon=lon, power=power, height=height, gain=gain, adir=adir, freq=freq, tone=tone, offset=offset, comment=comment )
 

--- a/owrx/kiss.py
+++ b/owrx/kiss.py
@@ -39,6 +39,7 @@ IGLOGIN {callsign} {password}
             )
 
             if pm["aprs_igate_beacon"]:
+                #Format beacon lat/lon
                 lat = pm["receiver_gps"]["lat"]
                 lon = pm["receiver_gps"]["lon"]
                 direction_ns = "N" if lat > 0 else "S"
@@ -48,10 +49,21 @@ IGLOGIN {callsign} {password}
                 lat = "{0:02d}^{1:05.2f}{2}".format(int(lat), (lat - int(lat)) * 60, direction_ns)
                 lon = "{0:03d}^{1:05.2f}{2}".format(int(lon), (lon - int(lon)) * 60, direction_we)
 
+                #Format beacon details
+                symbol  = str(pm["aprs_igate_symbol"])             if checkKey(pm, "aprs_igate_symbol")  else "R&"
+                power   = str(pm["aprs_igate_power"])              if checkKey(pm, "aprs_igate_power")   else "0"
+                height  = "HEIGHT=" + str(pm["aprs_igate_height"]) if checkKey(pm, "aprs_igate_height")  else ""
+                gain    = "GAIN=" + str(pm["aprs_igate_gain"])     if checkKey(pm, "aprs_igate_gain")    else ""
+                adir    = "DIR=" + str(pm["aprs_igate_dir"])       if checkKey(pm, "aprs_igate_dir")     else ""
+                freq    = "FREQ=" + str(pm["aprs_igate_freq"])     if checkKey(pm, "aprs_igate_freq")    else ""
+                tone    = "TONE=" + str(pm["aprs_igate_tone"])     if checkKey(pm, "aprs_igate_tone")    else ""
+                offset  = "OFFSET=" + str(pm["aprs_igate_offset"]) if checkKey(pm, "aprs_igate_offset")  else ""
+                comment = str(pm["aprs_igate_comment"])            if checkKey(pm, "aprs_igate_comment") else "OpenWebRX APRS gateway"
+
                 config += """
-PBEACON sendto=IG delay=0:30 every=60:00 symbol="igate" overlay=R lat={lat} long={lon} comment="OpenWebRX APRS gateway"
+PBEACON sendto=IG delay=0:30 every=60:00 symbol={symbol} lat={lat} long={lon} POWER={power} {height} {gain} {adir} {freq} {tone} {offset} comment={comment}
                 """.format(
-                    lat=lat, lon=lon
+                    symbol=symbol, lat=lat, lon=lon, power=power, height=height, gain=gain, adir=adir, freq=freq, tone=tone, offset=offset, comment=comment
                 )
 
         return config

--- a/owrx/kiss.py
+++ b/owrx/kiss.py
@@ -60,8 +60,10 @@ IGLOGIN {callsign} {password}
                 offset  = "OFFSET=" + str(pm["aprs_igate_offset"]) if "aprs_igate_offset"  in pm else ""
                 comment = str(pm["aprs_igate_comment"])            if "aprs_igate_comment" in pm else "\"OpenWebRX APRS gateway\""
 
-                if(comment[0] != '"' or comment[len(comment)-1] != '"'):
+                if(len(comment) > 0 and ((comment[0] != '"') or (comment[len(comment)-1] != '"')))):
+                    logger.info(comment)
                     comment = "\"" + comment + "\""
+                    logger.info(comment)
 
                 pbeacon= "PBEACON sendto=IG delay=0:30 every=60:00 symbol={symbol} lat={lat} long={lon} POWER={power} {height} {gain} {adir} {freq} {tone} {offset} comment={comment}".format(
                     symbol=symbol, lat=lat, lon=lon, power=power, height=height, gain=gain, adir=adir, freq=freq, tone=tone, offset=offset, comment=comment )

--- a/owrx/kiss.py
+++ b/owrx/kiss.py
@@ -11,6 +11,7 @@ FESC = 0xDB
 TFEND = 0xDC
 TFESC = 0xDD
 
+FEET_PER_METER = 3.28084
 
 class DirewolfConfig(object):
     def getConfig(self, port, is_service):
@@ -52,7 +53,6 @@ IGLOGIN {callsign} {password}
                 #Format beacon details
                 symbol  = str(pm["aprs_igate_symbol"])             if "aprs_igate_symbol"  in pm else "R&"
                 power   = str(pm["aprs_igate_power"])              if "aprs_igate_power"   in pm else "0"
-                height  = "HEIGHT=" + str(pm["aprs_igate_height"]) if "aprs_igate_height"  in pm else ""
                 gain    = "GAIN=" + str(pm["aprs_igate_gain"])     if "aprs_igate_gain"    in pm else ""
                 adir    = "DIR=" + str(pm["aprs_igate_dir"])       if "aprs_igate_dir"     in pm else ""
                 freq    = "FREQ=" + str(pm["aprs_igate_freq"])     if "aprs_igate_freq"    in pm else ""
@@ -60,19 +60,26 @@ IGLOGIN {callsign} {password}
                 offset  = "OFFSET=" + str(pm["aprs_igate_offset"]) if "aprs_igate_offset"  in pm else ""
                 comment = str(pm["aprs_igate_comment"])            if "aprs_igate_comment" in pm else "\"OpenWebRX APRS gateway\""
 
+                height = ""
+                if "aprs_igate_height":
+                    try:
+                        height_m = float(pm["aprs_igate_height"])
+                        height_ft = int(height_m * FEET_PER_METER)
+                        height = "HEIGHT=" + str(height_ft)
+                    except:
+                        logger.error("Cannot parse 'aprs_igate_height': " + str(pm["aprs_igate_height"]))
+
                 if((len(comment) > 0) and ((comment[0] != '"') or (comment[len(comment)-1] != '"'))):
                     comment = "\"" + comment + "\""
                 elif(len(comment) == 0):
                     comment = "\"\""
 
-                pbeacon= "PBEACON sendto=IG delay=0:30 every=60:00 symbol={symbol} lat={lat} long={lon} POWER={power} {height} {gain} {adir} {freq} {tone} {offset} comment={comment}".format(
+                pbeacon = "PBEACON sendto=IG delay=0:30 every=60:00 symbol={symbol} lat={lat} long={lon} POWER={power} {height} {gain} {adir} {freq} {tone} {offset} comment={comment}".format(
                     symbol=symbol, lat=lat, lon=lon, power=power, height=height, gain=gain, adir=adir, freq=freq, tone=tone, offset=offset, comment=comment )
 
                 logger.info("APRS PBEACON String: " + pbeacon)
                 
-                config += """
-                          {pbeacon}
-                          """.format(pbeacon=pbeacon)
+                config += "\n" + pbeacon + "\n"
 
         return config
 

--- a/owrx/kiss.py
+++ b/owrx/kiss.py
@@ -62,7 +62,7 @@ IGLOGIN {callsign} {password}
 
                 if((len(comment) > 0) and ((comment[0] != '"') or (comment[len(comment)-1] != '"'))):
                     comment = "\"" + comment + "\""
-                else if(len(comment) == 0):
+                elif(len(comment) == 0):
                     comment = "\"\""
 
                 pbeacon= "PBEACON sendto=IG delay=0:30 every=60:00 symbol={symbol} lat={lat} long={lon} POWER={power} {height} {gain} {adir} {freq} {tone} {offset} comment={comment}".format(

--- a/owrx/kiss.py
+++ b/owrx/kiss.py
@@ -71,7 +71,7 @@ IGLOGIN {callsign} {password}
                 elif(len(comment) == 0):
                     comment = "\"\""
 
-                pbeacon = "PBEACON sendto=IG delay=0:30 every=60:00 symbol={symbol} lat={lat} long={lon} POWER=0 {height} {gain} {adir} comment={comment}".format(
+                pbeacon = "PBEACON sendto=IG delay=0:30 every=60:00 symbol={symbol} lat={lat} long={lon} {height} {gain} {adir} comment={comment}".format(
                     symbol=symbol, lat=lat, lon=lon, height=height, gain=gain, adir=adir, comment=comment )
 
                 logger.info("APRS PBEACON String: " + pbeacon)

--- a/owrx/kiss.py
+++ b/owrx/kiss.py
@@ -60,11 +60,8 @@ IGLOGIN {callsign} {password}
                 offset  = "OFFSET=" + str(pm["aprs_igate_offset"]) if "aprs_igate_offset"  in pm else ""
                 comment = str(pm["aprs_igate_comment"])            if "aprs_igate_comment" in pm else "\"OpenWebRX APRS gateway\""
 
-                logger.info(str(len(comment)))
                 if((len(comment) > 0) and ((comment[0] != '"') or (comment[len(comment)-1] != '"'))):
-                    logger.info(comment)
                     comment = "\"" + comment + "\""
-                    logger.info(comment)
 
                 pbeacon= "PBEACON sendto=IG delay=0:30 every=60:00 symbol={symbol} lat={lat} long={lon} POWER={power} {height} {gain} {adir} {freq} {tone} {offset} comment={comment}".format(
                     symbol=symbol, lat=lat, lon=lon, power=power, height=height, gain=gain, adir=adir, freq=freq, tone=tone, offset=offset, comment=comment )

--- a/owrx/kiss.py
+++ b/owrx/kiss.py
@@ -62,6 +62,8 @@ IGLOGIN {callsign} {password}
 
                 if((len(comment) > 0) and ((comment[0] != '"') or (comment[len(comment)-1] != '"'))):
                     comment = "\"" + comment + "\""
+                else if(len(comment) > 0):
+                    comment = "\"\""
 
                 pbeacon= "PBEACON sendto=IG delay=0:30 every=60:00 symbol={symbol} lat={lat} long={lon} POWER={power} {height} {gain} {adir} {freq} {tone} {offset} comment={comment}".format(
                     symbol=symbol, lat=lat, lon=lon, power=power, height=height, gain=gain, adir=adir, freq=freq, tone=tone, offset=offset, comment=comment )

--- a/owrx/kiss.py
+++ b/owrx/kiss.py
@@ -60,7 +60,7 @@ IGLOGIN {callsign} {password}
                 offset  = "OFFSET=" + str(pm["aprs_igate_offset"]) if "aprs_igate_offset"  in pm else ""
                 comment = str(pm["aprs_igate_comment"])            if "aprs_igate_comment" in pm else "\"OpenWebRX APRS gateway\""
 
-                if(len(comment) > 0 and ((comment[0] != '"') or (comment[len(comment)-1] != '"')))):
+                if((len(comment) > 0) and ((comment[0] != '"') or (comment[len(comment)-1] != '"'))):
                     logger.info(comment)
                     comment = "\"" + comment + "\""
                     logger.info(comment)

--- a/owrx/kiss.py
+++ b/owrx/kiss.py
@@ -62,7 +62,7 @@ IGLOGIN {callsign} {password}
 
                 if((len(comment) > 0) and ((comment[0] != '"') or (comment[len(comment)-1] != '"'))):
                     comment = "\"" + comment + "\""
-                else if(len(comment) > 0):
+                else if(len(comment) == 0):
                     comment = "\"\""
 
                 pbeacon= "PBEACON sendto=IG delay=0:30 every=60:00 symbol={symbol} lat={lat} long={lon} POWER={power} {height} {gain} {adir} {freq} {tone} {offset} comment={comment}".format(

--- a/owrx/kiss.py
+++ b/owrx/kiss.py
@@ -60,15 +60,14 @@ IGLOGIN {callsign} {password}
                 offset  = "OFFSET=" + str(pm["aprs_igate_offset"]) if "aprs_igate_offset"  in pm else ""
                 comment = str(pm["aprs_igate_comment"])            if "aprs_igate_comment" in pm else "OpenWebRX APRS gateway"
 
-                pbeacon= """
-PBEACON sendto=IG delay=0:30 every=60:00 symbol={symbol} lat={lat} long={lon} POWER={power} {height} {gain} {adir} {freq} {tone} {offset} comment={comment}
-                """.format(
-                    symbol=symbol, lat=lat, lon=lon, power=power, height=height, gain=gain, adir=adir, freq=freq, tone=tone, offset=offset, comment=comment
-                )
+                pbeacon= "PBEACON sendto=IG delay=0:30 every=60:00 symbol={symbol} lat={lat} long={lon} POWER={power} {height} {gain} {adir} {freq} {tone} {offset} comment={comment}".format(
+                    symbol=symbol, lat=lat, lon=lon, power=power, height=height, gain=gain, adir=adir, freq=freq, tone=tone, offset=offset, comment=comment )
 
                 logger.info("APRS PBEACON String: " + pbeacon)
                 
-                config += pbeacon
+                config += """
+                          {pbeacon}
+                          """.format(pbeacon=pbeacon)
 
         return config
 

--- a/owrx/kiss.py
+++ b/owrx/kiss.py
@@ -60,11 +60,15 @@ IGLOGIN {callsign} {password}
                 offset  = "OFFSET=" + str(pm["aprs_igate_offset"]) if "aprs_igate_offset"  in pm else ""
                 comment = str(pm["aprs_igate_comment"])            if "aprs_igate_comment" in pm else "OpenWebRX APRS gateway"
 
-                config += """
+                pbeacon= """
 PBEACON sendto=IG delay=0:30 every=60:00 symbol={symbol} lat={lat} long={lon} POWER={power} {height} {gain} {adir} {freq} {tone} {offset} comment={comment}
                 """.format(
                     symbol=symbol, lat=lat, lon=lon, power=power, height=height, gain=gain, adir=adir, freq=freq, tone=tone, offset=offset, comment=comment
                 )
+
+                logger.info("APRS PBEACON String: " + pbeacon)
+                
+                config += pbeacon
 
         return config
 

--- a/owrx/kiss.py
+++ b/owrx/kiss.py
@@ -58,7 +58,7 @@ IGLOGIN {callsign} {password}
                 freq    = "FREQ=" + str(pm["aprs_igate_freq"])     if "aprs_igate_freq"    in pm else ""
                 tone    = "TONE=" + str(pm["aprs_igate_tone"])     if "aprs_igate_tone"    in pm else ""
                 offset  = "OFFSET=" + str(pm["aprs_igate_offset"]) if "aprs_igate_offset"  in pm else ""
-                comment = str(pm["aprs_igate_comment"])            if "aprs_igate_comment" in pm else "OpenWebRX APRS gateway"
+                comment = str(pm["aprs_igate_comment"])            if "aprs_igate_comment" in pm else "\"OpenWebRX APRS gateway\""
 
                 pbeacon= "PBEACON sendto=IG delay=0:30 every=60:00 symbol={symbol} lat={lat} long={lon} POWER={power} {height} {gain} {adir} {freq} {tone} {offset} comment={comment}".format(
                     symbol=symbol, lat=lat, lon=lon, power=power, height=height, gain=gain, adir=adir, freq=freq, tone=tone, offset=offset, comment=comment )

--- a/owrx/kiss.py
+++ b/owrx/kiss.py
@@ -60,7 +60,7 @@ IGLOGIN {callsign} {password}
                 offset  = "OFFSET=" + str(pm["aprs_igate_offset"]) if "aprs_igate_offset"  in pm else ""
                 comment = str(pm["aprs_igate_comment"])            if "aprs_igate_comment" in pm else "\"OpenWebRX APRS gateway\""
 
-                if(comment[0] != '"'):
+                if(comment[0] != '"' or comment[len(comment)-1] != '"'):
                     comment = "\"" + comment + "\""
 
                 pbeacon= "PBEACON sendto=IG delay=0:30 every=60:00 symbol={symbol} lat={lat} long={lon} POWER={power} {height} {gain} {adir} {freq} {tone} {offset} comment={comment}".format(

--- a/owrx/kiss.py
+++ b/owrx/kiss.py
@@ -52,16 +52,13 @@ IGLOGIN {callsign} {password}
 
                 #Format beacon details
                 symbol  = str(pm["aprs_igate_symbol"])             if "aprs_igate_symbol"  in pm else "R&"
-                power   = str(pm["aprs_igate_power"])              if "aprs_igate_power"   in pm else "0"
                 gain    = "GAIN=" + str(pm["aprs_igate_gain"])     if "aprs_igate_gain"    in pm else ""
                 adir    = "DIR=" + str(pm["aprs_igate_dir"])       if "aprs_igate_dir"     in pm else ""
-                freq    = "FREQ=" + str(pm["aprs_igate_freq"])     if "aprs_igate_freq"    in pm else ""
-                tone    = "TONE=" + str(pm["aprs_igate_tone"])     if "aprs_igate_tone"    in pm else ""
-                offset  = "OFFSET=" + str(pm["aprs_igate_offset"]) if "aprs_igate_offset"  in pm else ""
                 comment = str(pm["aprs_igate_comment"])            if "aprs_igate_comment" in pm else "\"OpenWebRX APRS gateway\""
 
+                #Convert height from meters to feet if specified
                 height = ""
-                if "aprs_igate_height":
+                if "aprs_igate_height" in pm:
                     try:
                         height_m = float(pm["aprs_igate_height"])
                         height_ft = round(height_m * FEET_PER_METER)
@@ -74,8 +71,8 @@ IGLOGIN {callsign} {password}
                 elif(len(comment) == 0):
                     comment = "\"\""
 
-                pbeacon = "PBEACON sendto=IG delay=0:30 every=60:00 symbol={symbol} lat={lat} long={lon} POWER={power} {height} {gain} {adir} {freq} {tone} {offset} comment={comment}".format(
-                    symbol=symbol, lat=lat, lon=lon, power=power, height=height, gain=gain, adir=adir, freq=freq, tone=tone, offset=offset, comment=comment )
+                pbeacon = "PBEACON sendto=IG delay=0:30 every=60:00 symbol={symbol} lat={lat} long={lon} POWER=0 {height} {gain} {adir} comment={comment}".format(
+                    symbol=symbol, lat=lat, lon=lon, height=height, gain=gain, adir=adir, comment=comment )
 
                 logger.info("APRS PBEACON String: " + pbeacon)
                 

--- a/owrx/kiss.py
+++ b/owrx/kiss.py
@@ -60,6 +60,7 @@ IGLOGIN {callsign} {password}
                 offset  = "OFFSET=" + str(pm["aprs_igate_offset"]) if "aprs_igate_offset"  in pm else ""
                 comment = str(pm["aprs_igate_comment"])            if "aprs_igate_comment" in pm else "\"OpenWebRX APRS gateway\""
 
+                logger.info(str(len(comment)))
                 if((len(comment) > 0) and ((comment[0] != '"') or (comment[len(comment)-1] != '"'))):
                     logger.info(comment)
                     comment = "\"" + comment + "\""


### PR DESCRIPTION
This is a PR offering the changes I made regarding issue #198.  This allows a user to customize details about their APRS IGate becaon reported to the APRS network.  

This is my first time contributing to this project.  Please let me know if there is anything I should change or add to meet this projects coding guidelines or standards, if there is any additional documentation I should provide, any config sanitation or handling missing, or any other features that may be relevant to this PR.

**The following are the relevant newly customizable beacon details:**

Symbol in its two-character form as specified by the APRS spec at http://www.aprs.org/symbols/symbols-new.txt
  Default: Receive only IGate (do not send msgs back to RF)  
aprs_igate_symbol = "R&"

Custom comment about igate 
  Default: OpenWebRX APRS gateway
aprs_igate_comment = "OpenWebRX APRS gateway"

Antenna Power, Height, Gain 
  Unspecified by default
Transmitter power (0 by default as only RX is supported)
aprs_igate_power = "0"
Antenna height in feet
aprs_igate_height = "20"
Antenna gain in dBi
aprs_igate_gain = "0"
Antenna direction (N, NE, E, SE, S, SW, W, NW).  Omnidirectional by default
aprs_igate_dir = "NE"

Frequency info to contact you by voice
  Unspecified by default
aprs_igate_freq = "146.955"
aprs_igate_tone = "74.4"
aprs_igate_offset = "-0.60"