### PR TITLE
Set proper config options for HPSDR connector

### DIFF
--- a/owrx/form/input/__init__.py
+++ b/owrx/form/input/__init__.py
@@ -107,8 +107,8 @@ class TextInput(Input):
 
 
 class NumberInput(Input):
-    def __init__(self, id, label, infotext=None, append="", converter: Converter = None):
-        super().__init__(id, label, infotext, converter=converter)
+    def __init__(self, id, label, infotext=None, append="", converter: Converter = None, validator: Validator = None):
+        super().__init__(id, label, infotext, converter=converter, validator=validator)
         self.step = None
         self.append = append
 

--- a/owrx/form/input/validator.py
+++ b/owrx/form/input/validator.py
@@ -12,3 +12,15 @@ class RequiredValidator(Validator):
     def validate(self, key, value):
         if value is None or value == "":
             raise ValidationError(key, "Field is required")
+
+class RangeValidator(Validator):
+    def __init__(self, minValue, maxValue):
+        self.minValue = minValue
+        self.maxValue = maxValue
+
+    def validate(self, key, value):
+        if value is None or value == "":
+            return # Ignore empty values
+        n = float(value)
+        if n < self.minValue or n > self.maxValue:
+            raise ValidationError(key, 'Value must be between %s and %s'%(self.minValue, self.maxValue))

--- a/owrx/source/hpsdr.py
+++ b/owrx/source/hpsdr.py
@@ -1,6 +1,8 @@
 from owrx.source.connector import ConnectorSource, ConnectorDeviceDescription
 from owrx.command import Option
+from owrx.form.error import ValidationError
 from owrx.form.input import Input, NumberInput, TextInput
+from owrx.form.input.validator import RangeValidator
 from typing import List
 
 # In order to use an HPSDR radio, you must install hpsdrconnector from https://github.com/jancona/hpsdrconnector
@@ -47,9 +49,9 @@ class HpsdrDeviceDescription(ConnectorDeviceDescription):
         return "HPSDR devices (Hermes / Hermes Lite 2 / Red Pitaya)"
 
     def getInputs(self) -> List[Input]:
-        return list(filter(lambda x : x.id != "rf_gain", super().getInputs())) + [
-            RemoteInput(), NumberInput("rf_gain", "LNA Gain", 
-            "LNA gain between 0 (-12dB) and 60 (48dB)"),
+        return super().getInputs() + [
+            RemoteInput(), 
+            NumberInput("rf_gain", "LNA Gain", "LNA gain between 0 (-12dB) and 60 (48dB)", validator=RangeValidator(0, 60)),
             ]
 
     def getDeviceOptionalKeys(self):

--- a/owrx/source/hpsdr.py
+++ b/owrx/source/hpsdr.py
@@ -1,5 +1,7 @@
 from owrx.source.connector import ConnectorSource, ConnectorDeviceDescription
 from owrx.command import Option
+from owrx.form.input import Input, NumberInput, TextInput
+from typing import List
 
 # In order to use an HPSDR radio, you must install hpsdrconnector from https://github.com/jancona/hpsdrconnector
 # These are the command line options available:
@@ -34,7 +36,25 @@ class HpsdrSource(ConnectorSource):
             )
         )
 
+class RemoteInput(TextInput):
+    def __init__(self):
+        super().__init__(
+            "remote", "Remote IP", infotext="Remote IP address to connect to."
+        )
 
 class HpsdrDeviceDescription(ConnectorDeviceDescription):
     def getName(self):
         return "HPSDR devices (Hermes / Hermes Lite 2 / Red Pitaya)"
+
+    def getInputs(self) -> List[Input]:
+        return list(filter(lambda x : x.id != "rf_gain", super().getInputs())) + [
+            RemoteInput(), NumberInput("rf_gain", "LNA Gain", 
+            "LNA gain between 0 (-12dB) and 60 (48dB)"),
+            ]
+
+    def getDeviceOptionalKeys(self):
+        return list(filter(lambda x : x not in ["rtltcp_compat", "iqswap"], super().getDeviceOptionalKeys())) + ["remote"]
+
+    def getProfileOptionalKeys(self):
+        return list(filter(lambda x : x != "iqswap", super().getProfileOptionalKeys()))
+


### PR DESCRIPTION
Add `remote` as an optional key with proper syntax. Remove `rtltcp_compat` and `iqswap` which don't apply. Make `rf_gain` a number so that it's passed as an integer value. 