### PR TITLE
Introducing proper SDRPlay gains, optional AGC reduction parameter.

### DIFF
--- a/owrx/source/sdrplay.py
+++ b/owrx/source/sdrplay.py
@@ -1,6 +1,7 @@
 from owrx.source.soapy import SoapyConnectorSource, SoapyConnectorDeviceDescription
 from owrx.form.input import Input, CheckboxInput, DropdownInput, NumberInput, DropdownEnum
 from owrx.form.input.device import BiasTeeInput, GainInput
+from owrx.form.input.validator import RangeValidator
 from typing import List
 
 
@@ -57,11 +58,13 @@ class SdrplayDeviceDescription(SoapyConnectorDeviceDescription):
             NumberInput(
                 "rfgain_sel",
                 "RF gain reduction",
+                validator=RangeValidator(0, 32),
             ),
             NumberInput(
                 "agc_setpoint",
                 "AGC setpoint",
                 append="dBFS",
+                validator=RangeValidator(-60, 0),
             ),
             GainInput(
                 "rf_gain",

--- a/owrx/source/sdrplay.py
+++ b/owrx/source/sdrplay.py
@@ -1,6 +1,6 @@
 from owrx.source.soapy import SoapyConnectorSource, SoapyConnectorDeviceDescription
-from owrx.form.input import Input, CheckboxInput, DropdownInput, DropdownEnum
-from owrx.form.input.device import BiasTeeInput
+from owrx.form.input import Input, CheckboxInput, DropdownInput, NumberInput, DropdownEnum
+from owrx.form.input.device import BiasTeeInput, GainInput
 from typing import List
 
 
@@ -14,6 +14,8 @@ class SdrplaySource(SoapyConnectorSource):
                 "dab_notch": "dabnotch_ctrl",
                 "if_mode": "if_mode",
                 "external_reference": "extref_ctrl",
+                "rfgain_sel": "rfgain_sel",
+                "agc_setpoint": "agc_setpoint",
             }
         )
         return mappings
@@ -36,9 +38,6 @@ class SdrplayDeviceDescription(SoapyConnectorDeviceDescription):
     def getName(self):
         return "SDRPlay device (RSP1, RSP2, RSPDuo, RSPDx)"
 
-    def getGainStages(self):
-        return ["RFGR", "IFGR"]
-
     def getInputs(self) -> List[Input]:
         return super().getInputs() + [
             BiasTeeInput(),
@@ -55,10 +54,24 @@ class SdrplayDeviceDescription(SoapyConnectorDeviceDescription):
                 "IF Mode",
                 IfModeOptions,
             ),
+            NumberInput(
+                "rfgain_sel",
+                "RF gain reduction",
+            ),
+            NumberInput(
+                "agc_setpoint",
+                "AGC setpoint",
+                append="dBFS",
+            ),
+            GainInput(
+                "rf_gain",
+                "IF gain reduction",
+                has_agc=self.hasAgc(),
+            ),
         ]
 
     def getDeviceOptionalKeys(self):
-        return super().getDeviceOptionalKeys() + ["bias_tee", "rf_notch", "dab_notch", "if_mode"]
+        return super().getDeviceOptionalKeys() + ["bias_tee", "rf_notch", "dab_notch", "if_mode", "rfgain_sel", "agc_setpoint"]
 
     def getProfileOptionalKeys(self):
-        return super().getProfileOptionalKeys() + ["bias_tee", "rf_notch", "dab_notch", "if_mode"]
+        return super().getProfileOptionalKeys() + ["bias_tee", "rf_notch", "dab_notch", "if_mode", "rfgain_sel", "agc_setpoint"]


### PR DESCRIPTION
This change fixes somewhat misguided SDRPlay gains configuration by replacing it with two separate optional parameters:

1) The original "Device Gain", renamed to "IF gain reduction", acts as a regular gain, with the AGC option. Since higher values make gain lower in RSPs, it is renamed to "reduction".

2) The new "RF gain reduction" controls the LNA gain. There is no AGC option for it, and it is not measured in dB, so it is just a value. Same as above, higher values make LNA gain lower.

I have also added the optional "AGC setpoint" parameter (in dbFS) which determines when AGC kicks in.