### PR TITLE
Support for additional parameters available in SoapySDRPlay3

### DIFF
--- a/owrx/source/sdrplay.py
+++ b/owrx/source/sdrplay.py
@@ -1,5 +1,6 @@
 from owrx.source.soapy import SoapyConnectorSource, SoapyConnectorDeviceDescription
-from owrx.form.input import Input, CheckboxInput, DropdownInput, DropdownEnum
+from owrx.form.input import Input, CheckboxInput, DropdownInput, NumberInput, DropdownEnum
+from owrx.form.input.validator import RangeValidator
 from owrx.form.input.device import BiasTeeInput
 from typing import List
 
@@ -14,6 +15,9 @@ class SdrplaySource(SoapyConnectorSource):
                 "dab_notch": "dabnotch_ctrl",
                 "if_mode": "if_mode",
                 "external_reference": "extref_ctrl",
+                "gain_ctrl_mode": "gain_ctrl_mode",
+                "agc_setpoint": "agc_setpoint",
+                "rfgain_sel": "rfgain_sel"
             }
         )
         return mappings
@@ -27,6 +31,16 @@ class IfModeOptions(DropdownEnum):
     IFMODE_450 = "450kHz"
     IFMODE_1620 = "1620kHz"
     IFMODE_2048 = "2048kHz"
+
+    def __str__(self):
+        return self.value
+
+
+class GainModelOptions(DropdownEnum):
+    GMODEL_LEGACY = "LEGACY"
+    GMODEL_DB = "DB"
+    GMODEL_RFATT = "RFATT"
+    GMODEL_STEPS = "STEPS"
 
     def __str__(self):
         return self.value
@@ -55,10 +69,26 @@ class SdrplayDeviceDescription(SoapyConnectorDeviceDescription):
                 "IF Mode",
                 IfModeOptions,
             ),
+            DropdownInput(
+                "gain_ctrl_model",
+                "Gain Control Model",
+                GainModelOptions,
+            ),
+            NumberInput(
+                "agc_setpoint",
+                "AGC Setpoint",
+                append="dBFS",
+                validator=RangeValidator(-60, 0),
+            ),
+            NumberInput(
+                "rfgain_sel",
+                "RF Gain Reduction",
+                validator=RangeValidator(0, 32),
+            ),
         ]
 
     def getDeviceOptionalKeys(self):
-        return super().getDeviceOptionalKeys() + ["bias_tee", "rf_notch", "dab_notch", "if_mode"]
+        return super().getDeviceOptionalKeys() + ["bias_tee", "rf_notch", "dab_notch", "if_mode", "gain_ctrl_mode", "agc_setpoint", "rfgain_sel"]
 
     def getProfileOptionalKeys(self):
-        return super().getProfileOptionalKeys() + ["bias_tee", "rf_notch", "dab_notch", "if_mode"]
+        return super().getProfileOptionalKeys() + ["bias_tee", "rf_notch", "dab_notch", "if_mode", "gain_ctrl_mode", "agc_setpoint", "rfgain_sel"]

--- a/owrx/source/sdrplay.py
+++ b/owrx/source/sdrplay.py
@@ -41,6 +41,7 @@ class GainModelOptions(DropdownEnum):
     GMODEL_DB = "DB"
     GMODEL_RFATT = "RFATT"
     GMODEL_STEPS = "STEPS"
+    GMODEL_IFGR = "IFGR"
 
     def __str__(self):
         return self.value

--- a/owrx/source/sdrplay.py
+++ b/owrx/source/sdrplay.py
@@ -15,7 +15,7 @@ class SdrplaySource(SoapyConnectorSource):
                 "dab_notch": "dabnotch_ctrl",
                 "if_mode": "if_mode",
                 "external_reference": "extref_ctrl",
-                "gain_ctrl_mode": "gain_ctrl_mode",
+                "gain_model": "gain_ctrl_model",
                 "agc_setpoint": "agc_setpoint",
                 "rfgain_sel": "rfgain_sel"
             }
@@ -58,11 +58,11 @@ class SdrplayDeviceDescription(SoapyConnectorDeviceDescription):
             BiasTeeInput(),
             CheckboxInput(
                 "rf_notch",
-                "Enable RF notch filter",
+                "Enable RF Notch Filter",
             ),
             CheckboxInput(
                 "dab_notch",
-                "Enable DAB notch filter",
+                "Enable DAB Notch Filter",
             ),
             DropdownInput(
                 "if_mode",
@@ -70,7 +70,7 @@ class SdrplayDeviceDescription(SoapyConnectorDeviceDescription):
                 IfModeOptions,
             ),
             DropdownInput(
-                "gain_ctrl_model",
+                "gain_model",
                 "Gain Control Model",
                 GainModelOptions,
             ),
@@ -88,7 +88,7 @@ class SdrplayDeviceDescription(SoapyConnectorDeviceDescription):
         ]
 
     def getDeviceOptionalKeys(self):
-        return super().getDeviceOptionalKeys() + ["bias_tee", "rf_notch", "dab_notch", "if_mode", "gain_ctrl_mode", "agc_setpoint", "rfgain_sel"]
+        return super().getDeviceOptionalKeys() + ["bias_tee", "rf_notch", "dab_notch", "if_mode", "gain_model", "agc_setpoint", "rfgain_sel"]
 
     def getProfileOptionalKeys(self):
-        return super().getProfileOptionalKeys() + ["bias_tee", "rf_notch", "dab_notch", "if_mode", "gain_ctrl_mode", "agc_setpoint", "rfgain_sel"]
+        return super().getProfileOptionalKeys() + ["bias_tee", "rf_notch", "dab_notch", "if_mode", "gain_model", "agc_setpoint", "rfgain_sel"]


### PR DESCRIPTION
Since Franco is busy adding different gain control models to SoapySDRPlay3, I have added support for the additional parameters available in SoapySDRPlay3:

1) **gain_model** is the gain control model selector Franco recently added:

https://github.com/pothosware/SoapySDRPlay3/commit/e3cdf7ff27f3da12d3473845e00239b7acbae92c

2) **rfgain_sel** is the LNA "state selector" for choosing the gain. This is the name used in SoapySDRPlay3. You can rename it if you like, just keep the mapping.

3) **agc_setpoint** determines how aggressive AGC is, by choosing when it kicks on.

