### PR TITLE
Allowing failed source to restart without having to restart whole OWRX.

### DIFF
--- a/owrx/source/__init__.py
+++ b/owrx/source/__init__.py
@@ -274,8 +274,10 @@ class SdrSource(ABC):
             if self.monitor:
                 return
 
-            if self.isFailed():
-                return
+            # allow failed sdr source to restart, without having to
+            # restart entire OpenWebRX
+            #if self.isFailed():
+            #    return
 
             try:
                 self.preStart()


### PR DESCRIPTION
Current OWRX policy is to make any once-failed device unavailable until the entire OWRX service is restarted, or the failed device is disabled and reenabled in the Settings.

This is highly inconvenient for devices that tend to have occasional failures, such as RSP, since the admin may not be able to restart OWRX if such a device happens to have a failure once in a few days.

The present change allows the user (or a background decoder) to restart a failed device.