### PR TITLE
Add --no-http-keep-alive to wget's arguments

### DIFF
--- a/docker/scripts/install-dependencies-sdrplay.sh
+++ b/docker/scripts/install-dependencies-sdrplay.sh
@@ -38,7 +38,7 @@ case $ARCH in
     ;;
 esac
 
-wget https://www.sdrplay.com/software/$BINARY
+wget --no-http-keep-alive https://www.sdrplay.com/software/$BINARY
 sh $BINARY --noexec --target sdrplay
 patch --verbose -Np0 < /install-lib.$ARCH.patch
 


### PR DESCRIPTION
When downloading SDRPlay API from sdrplay.com'server, it reports 403 forbidden error when the environment variable https_proxy is set. Adding --no-http-keep-live argument to wget will make the download working.