### PR TITLE
Set scope fields to 1 in receiver template descriptors.

### DIFF
--- a/owrx/reporting/pskreporter.py
+++ b/owrx/reporting/pskreporter.py
@@ -174,8 +174,8 @@ class Uploader(object):
             + Uploader.receieverDelimiter
             # number of fields
             + list(num_fields.to_bytes(2, "big"))
-            # padding
-            + [0x00, 0x00]
+            # scoped field count
+            + [0x00, 0x01]
             # receiverCallsign
             + [0x80, 0x02, 0xFF, 0xFF, 0x00, 0x00, 0x76, 0x8F]
             # receiverLocator


### PR DESCRIPTION
This change is necessary for the Options Template used for receiver information to be valid. See [RFC7011-3.4.2.2](https://datatracker.ietf.org/doc/html/rfc7011#section-3.4.2.2).
> The Scope Field Count MUST NOT be zero.

Without this change, IPFIX parsers may report a malformed template, e.g. Wireshark shows the template in OpenWebRX packets is malformed due to the scoped field count of 0.