### PR TITLE
Add SoapySDDC support

### DIFF
--- a/owrx/feature.py
+++ b/owrx/feature.py
@@ -71,6 +71,7 @@ class FeatureDetector(object):
         "fcdpp": ["soapy_connector", "soapy_fcdpp"],
         "bladerf": ["soapy_connector", "soapy_bladerf"],
         "sddc": ["sddc_connector"],
+        "sddc_soapy": ["soapy_connector", "soapy_sddc"],
         "hpsdr": ["hpsdr_connector"],
         "runds": ["runds_connector"],
         # optional features and their requirements
@@ -568,6 +569,18 @@ class FeatureDetector(object):
         You can find more information [here](https://github.com/jketterl/sddc_connector).
         """
         return self._check_connector("sddc_connector", LooseVersion("0.1"))
+
+    def has_soapy_sddc(self):
+        """
+        The [SoapySDR module for SDDC](https://github.com/ik1xpv/ExtIO_sddc)
+        devices can be used as an alternative to the `sddc_connector`, enabling
+        connectivity with SDR devices such as the RX666, RX888, HF103, etc.
+        Unlike the `sddc_connector`, the SoapySDR module relies solely on the CPU
+        and does not require an NVIDIA GPU.
+        You will need to compile SoapySDDC from source. Detailed installation
+        instructions are available on the [OpenWebRX Wiki](https://github.com/jketterl/openwebrx/wiki/SDDC-device-notes).
+        """
+        return self._has_soapy_driver("SDDC")
 
     def has_hpsdr_connector(self):
         """

--- a/owrx/source/sddc_soapy.py
+++ b/owrx/source/sddc_soapy.py
@@ -1,0 +1,54 @@
+from owrx.source.soapy import SoapyConnectorSource, SoapyConnectorDeviceDescription
+from owrx.form.input import Input, CheckboxInput
+from owrx.form.input.validator import Range
+from typing import List
+
+class SddcSoapySource(SoapyConnectorSource):
+    def getSoapySettingsMappings(self):
+        mappings = super().getSoapySettingsMappings()
+        mappings.update(
+            {
+                "bias_tee_hf": "UpdBiasT_HF",
+                "bias_tee_vhf": "UpdBiasT_VHF"
+            }
+        )
+        return mappings
+
+    def getDriver(self):
+        return "SDDC"
+
+class SddcSoapyDeviceDescription(SoapyConnectorDeviceDescription):
+    def getName(self):
+        return "BBRF103 / RX666 / RX888 (SDDC) device (via SoapySDR)"
+
+    def getInputs(self) -> List[Input]:
+        return super().getInputs() + [
+            CheckboxInput(
+                "bias_tee_hf",
+                "Enable BIAS-T for HF antenna port"
+            ),
+            CheckboxInput(
+                "bias_tee_vhf",
+                "Enable BIAS-T for VHF antenna port"
+            ),
+        ]
+
+    def getDeviceOptionalKeys(self):
+        return super().getDeviceOptionalKeys() + [
+            "bias_tee_hf", "bias_tee_vhf"
+        ]
+
+    def getGainStages(self):
+        return ["RF", "IF"]
+
+    def hasAgc(self):
+        return False
+
+    def getSampleRateRanges(self) -> List[Range]:
+        return [
+            Range(2000000),
+            Range(4000000),
+            Range(8000000),
+            Range(16000000),
+            Range(32000000),
+        ]


### PR DESCRIPTION
Tested with RX-888 mkII on OpenWebRX+

Known bugs:

1. If the device is already opened by a SoapySDR instance, running SoapySDRUtil --probe will cause SoapySDRUtil to crash.
2. Switching between VHF and HF while the device is still open will cause soapy_connector to crash, leading OpenWebRX+ to mark the device as failed. To switch bands, you must close and reopen the device.

These are all bugs within SoapySDDC itself.